### PR TITLE
Fix bouncingBalls brekage and "Clear" button

### DIFF
--- a/slides/slides.hs
+++ b/slides/slides.hs
@@ -151,7 +151,7 @@ bounce (w, h) (x, y) v
    y'   = y + fromIntegral v
 
 step :: State -> State
-step = map tail
+step = map (drop 1)
 
 ballShape :: Ball -> Shape ()
 ballShape []      = return ()
@@ -206,7 +206,6 @@ canWidth  = 700
 canHeight = 500
 
 -- TODO: On my machine the balls start lower than the mouse click position (Patrik).
--- TODO: After a few balls have disappeard the demo just stops.
 bouncingBalls :: Elem -> IO HandlerInfo
 bouncingBalls el = do
     canvas <- mkCanvas canWidth canHeight

--- a/slides/slides.hs
+++ b/slides/slides.hs
@@ -104,12 +104,11 @@ logos = column
 
 bouncing :: Slide
 bouncing = column
-    [ title "Bouncing balls live"
+    [ sized 0.08 $ title "Bouncing balls live"
     , verticallyCentered $ centered $ lift $ do
           e <- newElem "div"
           bouncingBalls e
           return e
-    , ""
     ]
 
 end :: Slide


### PR DESCRIPTION
`bouncingBalls` would break after running for a short while due to running `tail` on an empty list. Also, the "Clear" button was overlapped by an invisible slide due to the slightly ghetto placement method; using the new `sized` function fixes this.

The issue with balls appearing below the cursor is still there. See [this question](http://stackoverflow.com/questions/6773481/how-to-get-the-mouseevent-coordinates-for-an-element-that-has-css3-transform) for a breakdown of all the CSS fun that's going on here - not sure how to fix this in `haste-deck` yet, but transforming the mouse coordinates manually for the bouncing balls would probably do the trick.
